### PR TITLE
Fix NPCs Leaking Into Pal Lists

### DIFF
--- a/scripts/scrs/update_game_data.py
+++ b/scripts/scrs/update_game_data.py
@@ -404,6 +404,28 @@ def update_pal_data():
     monster_param_common = load_export_json('Character/DT_PalMonsterParameter_Common.json')
     pal_name_l10n = load_l10n_table('DT_PalNameText_Common.json')
     name_prefix_l10n = load_l10n_table('DT_NamePrefixText_Common.json')
+    human_param = load_export_json('Character/DT_PalHumanParameter.json')
+    human_param_common = load_export_json('Character/DT_PalHumanParameter_Common.json')
+    human_rows = {}
+    for d in [human_param, human_param_common]:
+        human_rows.update(_collect_export_rows(d))
+    human_rows_ci = {k.lower(): v for k, v in human_rows.items()}
+    def _is_human_npc(pal_id: str) -> bool:
+        hrow = human_rows.get(pal_id) or human_rows_ci.get(pal_id.lower())
+        if not hrow:
+            base_id = re.sub(r'_v\d+$', '', pal_id)
+            if base_id != pal_id:
+                hrow = human_rows.get(base_id) or human_rows_ci.get(base_id.lower())
+        if not hrow:
+            base_id = re.sub('^(BOSS_|NPC_|PREDATOR_|GYM_|RAID_|SUMMON_|QUEST_|POLICE_)', '', pal_id, flags=re.IGNORECASE)
+            if base_id != pal_id:
+                hrow = human_rows.get(base_id) or human_rows_ci.get(base_id.lower())
+        if not hrow or not isinstance(hrow, dict):
+            return False
+        is_pal = hrow.get('IsPal', True)
+        if isinstance(is_pal, dict):
+            is_pal = is_pal.get('value', True)
+        return not is_pal
     icon_rows = {}
     for data in [export_data, export_data_common]:
         if data:
@@ -493,6 +515,10 @@ def update_pal_data():
     processed_ids = set()
     for pal_id, row_data in sorted(icon_rows.items()):
         pal_id_lower = pal_id.lower()
+        monster_row = monster_rows.get(pal_id) or _monster_rows_ci.get(pal_id_lower)
+        if _is_human_npc(pal_id) or not monster_row:
+            processed_ids.add(pal_id_lower)
+            continue
         processed_ids.add(pal_id_lower)
         icon_data = row_data.get('Icon', {})
         icon_path = icon_data.get('AssetPathName', '') if isinstance(icon_data, dict) else ''
@@ -501,7 +527,6 @@ def update_pal_data():
             copied_icon = find_and_copy_icon(icon_filename, 'pals', pal_icon_subdirs)
         else:
             copied_icon = None
-        monster_row = monster_rows.get(pal_id) or _monster_rows_ci.get(pal_id.lower())
         display_name = resolve_pal_name(pal_id, monster_row)
         final_icon = copied_icon or f'/icons/pals/{pal_id}_icon_normal.webp'
         if not copied_icon:
@@ -535,6 +560,9 @@ def update_pal_data():
     for pal_id in sorted(monster_rows.keys()):
         pal_id_lower = pal_id.lower()
         if pal_id_lower in processed_ids:
+            continue
+        if _is_human_npc(pal_id):
+            processed_ids.add(pal_id_lower)
             continue
         processed_ids.add(pal_id_lower)
         monster_row = monster_rows[pal_id_lower] if pal_id_lower in monster_rows else monster_rows.get(pal_id, {})
@@ -711,6 +739,12 @@ def update_npc_data():
         r = _collect_export_rows(d)
         human_rows.update(r)
     human_rows_ci = {k.lower(): v for k, v in human_rows.items()}
+    monster_param = load_export_json('Character/DT_PalMonsterParameter.json')
+    monster_param_common = load_export_json('Character/DT_PalMonsterParameter_Common.json')
+    monster_rows = {}
+    for d in [monster_param, monster_param_common]:
+        monster_rows.update(_collect_export_rows(d))
+    monster_rows_ci = {k.lower(): v for k, v in monster_rows.items()}
     npc_icon_subdirs = [EXPORT_TEXTURES_DIR / 'PalIcon' / 'NPC', EXPORT_TEXTURES_DIR / 'PalIcon' / 'Normal']
     boss_icon_data = load_export_json('Character/DT_PalBossNPCIcon.json')
     boss_rows = _collect_export_rows(boss_icon_data)
@@ -745,6 +779,13 @@ def update_npc_data():
             if not is_pal:
                 seen.add(npc_id_lower)
                 updated_npcs.append(_make_npc_entry(npc_id, row_data, human_rows, human_rows_ci, npc_name_l10n, npc_l10n_lower, npc_icon_subdirs))
+            continue
+        # No IsPal flag to consult (e.g. generic templates like "Human"). A real pal
+        # always has a DT_PalMonsterParameter row; without one, it can't be a fightable
+        # pal, so treat it as an NPC rather than dropping it or leaking it into pals.
+        if npc_id not in monster_rows and npc_id_lower not in monster_rows_ci:
+            seen.add(npc_id_lower)
+            updated_npcs.append(_make_npc_entry(npc_id, row_data, human_rows, human_rows_ci, npc_name_l10n, npc_l10n_lower, npc_icon_subdirs))
     result = {'npcs': updated_npcs}
     save_resource_json('npcdata.json', result)
     print(f'  Total NPCs: {len(updated_npcs)}')
@@ -2810,14 +2851,15 @@ def update_breeding_data():
             continue
         ignore_combi = bool(data.get('IgnoreCombi', False))
         rarity = int(_safe_get(data, 'Rarity', 0))
+        duplicate_priority = _safe_get(data, 'CombiDuplicatePriority', 0) or 0
         is_variant = '_' in tribe
         is_base = internal_id == tribe
         if tribe in seen_tribes:
             existing = seen_tribes[tribe]
             if is_base or (existing['rank'] > rank and not existing['is_base']):
-                seen_tribes[tribe] = {'tribe': tribe, 'internal_id': internal_id, 'rank': rank, 'rarity': rarity, 'index': idx, 'is_variant': is_variant, 'ignore_combi': ignore_combi, 'is_base': is_base}
+                seen_tribes[tribe] = {'tribe': tribe, 'internal_id': internal_id, 'rank': rank, 'rarity': rarity, 'duplicate_priority': duplicate_priority, 'index': idx, 'is_variant': is_variant, 'ignore_combi': ignore_combi, 'is_base': is_base}
         else:
-            seen_tribes[tribe] = {'tribe': tribe, 'internal_id': internal_id, 'rank': rank, 'rarity': rarity, 'index': idx, 'is_variant': is_variant, 'ignore_combi': ignore_combi, 'is_base': is_base}
+            seen_tribes[tribe] = {'tribe': tribe, 'internal_id': internal_id, 'rank': rank, 'rarity': rarity, 'duplicate_priority': duplicate_priority, 'index': idx, 'is_variant': is_variant, 'ignore_combi': ignore_combi, 'is_base': is_base}
     pals = list(seen_tribes.values())
     tribe_map = {p['tribe']: p for p in pals if p['tribe'].upper() in name_map}
     pals = [p for p in pals if p['tribe'].upper() in name_map]
@@ -2847,14 +2889,11 @@ def update_breeding_data():
             cand.append(sorted_ranks[idx])
         if idx > 0:
             cand.append(sorted_ranks[idx - 1])
-        best, best_diff = None, float('inf')
-        for r in cand:
-            p = rank_to_best[r]
-            diff = abs(r - cp)
-            if diff < best_diff or (diff == best_diff and p['rank'] > best['rank']):
-                best_diff = diff
-                best = p
-        return best
+        entries = [(abs(r - cp), rank_to_best[r]) for r in cand]
+        if not entries:
+            return None
+        entries.sort(key=lambda e: (e[0], -e[1]['duplicate_priority']))
+        return entries[0][1]
     pair_to_child = {}
     child_to_pairs = {}
     import bisect

--- a/src/palworld_aio/editor/pal_editor/create_dialogs.py
+++ b/src/palworld_aio/editor/pal_editor/create_dialogs.py
@@ -806,7 +806,7 @@ class PalCreateDialog(QDialog):
         show_predator = self._show_predator_chk.isChecked() if hasattr(self, '_show_predator_chk') else False
         show_boss = self._show_boss_chk.isChecked() if hasattr(self, '_show_boss_chk') else False
         self.pal_list.clear()
-        for asset, name in sorted(PalFrame._NAMEMAP.items(), key=lambda kv: (kv[1], kv[0])):
+        for asset, name in sorted(PalFrame._PALMAP.items(), key=lambda kv: (kv[1], kv[0])):
             asset_lower = asset.lower()
             if search_text and search_text not in name.lower() and (search_text not in asset.lower()):
                 continue

--- a/src/palworld_aio/editor/pal_editor/legacy_frame.py
+++ b/src/palworld_aio/editor/pal_editor/legacy_frame.py
@@ -12,6 +12,7 @@ class PalFrame(QFrame):
     _cheat_mode = False
     _maps_loaded = False
     _NAMEMAP = {}
+    _PALMAP = {}
     _PASSMAP = {}
     _PASSRANK = {}
     _PASSFLAGS = {}
@@ -39,6 +40,7 @@ class PalFrame(QFrame):
         cls._SKILLMAP = dm.load_game_data_map('skills.json', 'skills')
         PALMAP = dm.load_game_data_map('characters.json', 'pals')
         NPCMAP = dm.load_game_data_map('characters.json', 'npcs')
+        cls._PALMAP = PALMAP
         cls._NAMEMAP = {**PALMAP, **NPCMAP}
         cls._PAL_ZUKAN = {}
         try:

--- a/src/palworld_aio/ui/dialogs/player_pal_dialog.py
+++ b/src/palworld_aio/ui/dialogs/player_pal_dialog.py
@@ -292,7 +292,7 @@ class PlayerPalActionDialog(QDialog):
             query = self.pal_search_input.text()
         query_lower = query.lower()
         self.pal_list.clear()
-        for asset, name in sorted(PalFrame._NAMEMAP.items(), key=lambda x: x[1]):
+        for asset, name in sorted(PalFrame._PALMAP.items(), key=lambda x: x[1]):
             asset_lower = asset.lower()
             is_predator = asset.upper().startswith('PREDATOR_')
             is_boss = any((asset.upper().startswith(p) for p in _BOSS_PREFIXES)) and not is_predator

--- a/src/palworld_aio/ui/tabs/breeding_tab.py
+++ b/src/palworld_aio/ui/tabs/breeding_tab.py
@@ -46,6 +46,12 @@ class _SelectPalDialog(PalCreateDialog):
     def __init__(self, parent=None):
         from palworld_aio.editor.pal_editor import PalFrame
         PalFrame._load_maps()
+        self._pal_info = {}
+        self._unique_combo_children = set()
+        breeding_data = getattr(parent, '_breeding_data', None)
+        if breeding_data:
+            self._pal_info = breeding_data.get('pal_info', {})
+            self._unique_combo_children = {c.get('child') for c in breeding_data.get('unique_combos', [])}
         super().__init__(pal_editor=None, is_party=False, slot_index=0, parent=parent)
         self.selected_asset = None
         self.selected_name = None
@@ -64,6 +70,12 @@ class _SelectPalDialog(PalCreateDialog):
                 self._breeding_ok_btn = btn
             elif 'Cancel' in txt or 'cancel' in txt:
                 self._breeding_cancel_btn = btn
+        if hasattr(self, '_show_standard_chk'):
+            self._show_standard_chk.hide()
+        if hasattr(self, '_show_predator_chk'):
+            self._show_predator_chk.hide()
+        if hasattr(self, '_show_boss_chk'):
+            self._show_boss_chk.hide()
         self._search_edit.textChanged.disconnect()
         self._search_edit.textChanged.connect(self._on_search)
 
@@ -72,40 +84,12 @@ class _SelectPalDialog(PalCreateDialog):
 
     def _filter_pal_list(self):
         text = self._search_edit.text().lower() if hasattr(self, '_search_edit') else ''
-        show_standard = self._show_standard_chk.isChecked() if hasattr(self, '_show_standard_chk') else True
-        show_boss = self._show_boss_chk.isChecked() if hasattr(self, '_show_boss_chk') else False
         self.pal_list.clear()
-        for asset, name in sorted(PalFrame._NAMEMAP.items(), key=lambda kv: (kv[1], kv[0])):
-            asset_lower = asset.lower()
-            if any((asset_lower.startswith(p) for p in ('summon_', 'quest_', 'raid_', 'predator_', 'police_'))):
+        for asset, info in sorted(self._pal_info.items(), key=lambda kv: (kv[1].get('name', kv[0]), kv[0])):
+            if info.get('ignore_combi') and asset not in self._unique_combo_children:
                 continue
-            if 'worldtreedragon' in asset_lower or 'oilrig' in asset_lower or 'tower' in asset_lower:
-                continue
-            if '_bossrush' in asset_lower:
-                continue
-            if asset_lower.startswith('gym_') and not asset_lower.endswith('_otomo'):
-                continue
-            otomo_key = asset_lower + '_otomo'
-            if otomo_key in PalFrame._NAMEMAP:
-                continue
-            boss_otomo_key = 'boss_' + asset_lower + '_otomo'
-            if boss_otomo_key in PalFrame._NAMEMAP:
-                continue
-            base_id = asset_lower
-            for prefix in ('boss_', 'gym_'):
-                if base_id.startswith(prefix):
-                    base_id = base_id[len(prefix):]
-            base_id = re.sub(r'_\d+$', '', base_id)
-            base_id = re.sub(r'_avatar|_servant|_otomo', '', base_id)
-            zukan = PalFrame._PAL_ZUKAN.get(base_id, -99)
-            if zukan != -99 and zukan < 0:
-                continue
+            name = info.get('name', asset)
             if text and text not in name.lower() and text not in asset.lower():
-                continue
-            is_variant = any((asset.upper().startswith(p) for p in ('BOSS_', 'PREDATOR_', 'GYM_', 'RAID_', 'POLICE_', 'SUMMON_')))
-            if is_variant and not show_boss:
-                continue
-            if not is_variant and not show_standard:
                 continue
             li = QListWidgetItem(name)
             li.setData(Qt.UserRole, asset)


### PR DESCRIPTION
This PR aims to fix #189 

### Summary

- Fixed update_game_data.py so Pal vs NPC classification is based on whether a character has a real DT_PalMonsterParameter row (combat stats) instead of blindly dumping every character-icon-table row into pals. NPCs with no monster-param row and no IsPal flag (e.g. the generic Human template) now correctly fall through to npcs instead of leaking into pals.
- Added PalFrame._PALMAP (pals-only) alongside the existing _NAMEMAP (pals+npcs, still used where NPC name lookups are legitimate, e.g. base-worker labels). Switched the breeding picker, the party/palbox "Add Pal" dialog, and the player pal search/delete dialog to source from _PALMAP so NPCs can no longer be selected as Pals.
- Reworked the breeding tab's "Select a Pal..." picker (_SelectPalDialog) to source candidates from breedingdata.json's pal_info (canonical species, already deduped) instead of the merged name map — dropped ~25 lines of manual prefix/otomo/zukan-index filtering that this replaces. Also excludes ignore_combi: True pals unless they appear as a child in unique_combos (keeps Jetragon via its self-breed combo, drops Astralym/World Tree Dragon which has no unique-combo path).