### PR TITLE
Move drag-and-drop handling from ToolsTab to MainWindow

### DIFF
--- a/src/palworld_aio/ui/main_window.py
+++ b/src/palworld_aio/ui/main_window.py
@@ -14,7 +14,7 @@ from i18n import t, set_language, load_resources, get_native_lang_name
 from common import get_versions, get_current_version, get_display_version, is_standalone
 from import_libs import run_with_loading
 from loading_manager import show_question
-from .tabs.tools_tab import center_on_parent
+from .tabs.tools_tab import center_on_parent, DropOverlay
 GITHUB_LATEST_ZIP = 'https://github.com/deafdudecomputers/PalworldSaveTools/releases/latest'
 from palworld_aio import constants
 from palworld_aio.ui.chrome.styles import ThemeManager, MENU_STYLE, DIALOG_STYLE as DARK_THEME_STYLE
@@ -336,6 +336,10 @@ class MainWindow(QMainWindow):
         self.status_bar.setFixedHeight(0)
         self.status_bar.hide()
         self.setStatusBar(self.status_bar)
+        self.setAcceptDrops(True)
+        self._drop_overlay = DropOverlay(self)
+        self._drop_overlay.setVisible(False)
+        self._drop_overlay.setGeometry(self.rect())
     _TAB_SETUP = {
         0: '_setup_tools_tab',
         1: '_setup_base_inventory_tab',
@@ -1170,6 +1174,44 @@ class MainWindow(QMainWindow):
         menu = ScrollableContextMenu(self)
         menu.add_action(self._create_action(t('deletion.ctx.remove_exclusion'), lambda v=val: self._remove_exclusion(excl_type, v)))
         menu.exec(panel.tree.viewport().mapToGlobal(pos))
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        if hasattr(self, '_drop_overlay'):
+            self._drop_overlay.setGeometry(self.rect())
+    def dragEnterEvent(self, event):
+        if event.mimeData().hasUrls():
+            urls = event.mimeData().urls()
+            if urls:
+                file_path = urls[0].toLocalFile()
+                if file_path.lower().endswith('.sav'):
+                    self._drop_overlay.setVisible(True)
+                    self._drop_overlay.raise_()
+                    event.acceptProposedAction()
+                    return
+        super().dragEnterEvent(event)
+    def dragMoveEvent(self, event):
+        if event.mimeData().hasUrls():
+            urls = event.mimeData().urls()
+            if urls:
+                file_path = urls[0].toLocalFile()
+                if file_path.lower().endswith('.sav'):
+                    event.acceptProposedAction()
+                    return
+        super().dragMoveEvent(event)
+    def dragLeaveEvent(self, event):
+        self._drop_overlay.setVisible(False)
+        super().dragLeaveEvent(event)
+    def dropEvent(self, event):
+        self._drop_overlay.setVisible(False)
+        if event.mimeData().hasUrls():
+            urls = event.mimeData().urls()
+            if urls:
+                file_path = urls[0].toLocalFile()
+                if file_path.lower().endswith('.sav'):
+                    save_manager.load_save(path=file_path, parent=self)
+                    event.acceptProposedAction()
+                    return
+        super().dropEvent(event)
     def _load_save(self):
         save_manager.load_save(parent=self)
     def _load_xgp_save(self):

--- a/src/palworld_aio/ui/tabs/tools_tab.py
+++ b/src/palworld_aio/ui/tabs/tools_tab.py
@@ -237,8 +237,6 @@ class ToolsTab(QWidget):
         self.parent_window = parent
         self.tool_buttons = []
         self._section_titles = []
-        self._drag_hover_active = False
-        self.setAcceptDrops(True)
         self._setup_ui()
     def _setup_ui(self):
         main_layout = QVBoxLayout(self)
@@ -250,8 +248,6 @@ class ToolsTab(QWidget):
         footer_row.addWidget(self._create_section('tools.section.converting', CONVERTING_TOOL_KEYS, self._run_converting_tool), stretch=1)
         footer_row.addWidget(self._create_section('tools.section.management', MANAGEMENT_TOOL_KEYS, self._run_management_tool), stretch=1)
         main_layout.addLayout(footer_row)
-        self._drop_overlay = DropOverlay(self)
-        self._drop_overlay.setVisible(False)
         self._setup_save_manager_connection()
     def _create_header_bar(self):
         return QWidget()
@@ -530,50 +526,6 @@ class ToolsTab(QWidget):
         self.fade_animation.setEndValue(1.0)
         self.fade_animation.setEasingCurve(QEasingCurve.OutCubic)
         self.fade_animation.start()
-    def dragEnterEvent(self, event):
-        if event.mimeData().hasUrls():
-            urls = event.mimeData().urls()
-            if urls:
-                file_path = urls[0].toLocalFile()
-                if file_path.lower().endswith('.sav'):
-                    self._drag_hover_active = True
-                    self._drop_overlay.setVisible(True)
-                    self._drop_overlay.raise_()
-                    event.acceptProposedAction()
-                    return
-        super().dragEnterEvent(event)
-    def dragMoveEvent(self, event):
-        if event.mimeData().hasUrls():
-            urls = event.mimeData().urls()
-            if urls:
-                file_path = urls[0].toLocalFile()
-                if file_path.lower().endswith('.sav'):
-                    event.acceptProposedAction()
-                    return
-        super().dragMoveEvent(event)
-    def dragLeaveEvent(self, event):
-        self._drag_hover_active = False
-        self._drop_overlay.setVisible(False)
-        super().dragLeaveEvent(event)
-    def dropEvent(self, event):
-        self._drag_hover_active = False
-        self._drop_overlay.setVisible(False)
-        if event.mimeData().hasUrls():
-            urls = event.mimeData().urls()
-            if urls:
-                file_path = urls[0].toLocalFile()
-                if file_path.lower().endswith('.sav'):
-                    self._load_save_from_path(file_path)
-                    event.acceptProposedAction()
-                    return
-        super().dropEvent(event)
-    def _load_save_from_path(self, path):
-        from palworld_aio.managers.save_manager import save_manager
-        save_manager.load_save(path=path, parent=self)
-    def resizeEvent(self, event):
-        super().resizeEvent(event)
-        if hasattr(self, '_drop_overlay'):
-            self._drop_overlay.setGeometry(self.rect())
     def _refresh_save_btns(self):
         import nerdfont as nf
         if hasattr(self, '_load_steam_btn') and self._load_steam_btn:


### PR DESCRIPTION
Fixes #199

Moves drag/drop event handlers and the DropOverlay from ToolsTab to MainWindow so dropping a .sav file works regardless of the active tab, not just Tools.

## Changes
- MainWindow now accepts drops, owns DropOverlay, handles dragEnter/dragMove/dragLeave/drop
- ToolsTab's drag-drop handling removed (was scoped to that tab only)