### PR TITLE
Warn before overwriting a save changed outside the app

### DIFF
--- a/resources/i18n/en_US.json
+++ b/resources/i18n/en_US.json
@@ -677,6 +677,8 @@
     "error.overlay.copy": "COPY TO CLIPBOARD",
     "error.overlay.title": "AN ERROR OCCURRED",
     "error.players_folder_missing": "Players folder missing",
+    "error.save_stale_msg": "Level.sav on disk has changed since it was loaded (it may have been re-saved by the game). Saving now will overwrite those changes with your in-memory edits.\n\nSave anyway?",
+    "error.save_stale_title": "Save File Changed",
     "error.title": "Error!",
     "error.tool": "Invalid choice or error running tool:",
     "exclusions.add_title": "Add to Exclusions",

--- a/resources/i18n/zh_CN.json
+++ b/resources/i18n/zh_CN.json
@@ -410,6 +410,8 @@
     "error.overlay.copy": "复制到剪贴板",
     "error.overlay.title": "发生错误",
     "error.players_folder_missing": "缺少 Players 文件夹",
+    "error.save_stale_msg": "磁盘上的 Level.sav 自加载后已发生变化（可能是游戏重新保存了存档）。现在保存将用内存中的修改覆盖这些变化。\n\n仍要保存吗？",
+    "error.save_stale_title": "存档文件已变化",
     "error.title": "错误！",
     "error.tool": "无效的选择或运行工具时发生错误：",
     "exclusions.add_title": "添加到排除项",

--- a/src/palworld_aio/constants.py
+++ b/src/palworld_aio/constants.py
@@ -47,6 +47,7 @@ EXCLUSIONS_FILE = os.path.join(get_user_config_dir(), 'deletion_exclusions.json'
 ZONE_EXCLUSIONS_FILE = os.path.join(get_user_config_dir(), 'zone_exclusions.json')
 current_save_path: str | None = None
 loaded_level_json = None
+loaded_level_mtime: float | None = None
 original_loaded_level_json = None
 backup_save_path = None
 srcGuildMapping = None

--- a/src/palworld_aio/managers/save_manager.py
+++ b/src/palworld_aio/managers/save_manager.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed
 from PySide6.QtWidgets import QFileDialog
 from PySide6.QtCore import QObject, Signal
-from loading_manager import show_critical
+from loading_manager import show_critical, show_question
 from palsav.gvas import GvasFile
 from palsav.core import decompress_sav_to_gvas
 from palworld_aio.managers.data_manager import load_game_data_map
@@ -88,6 +88,7 @@ class SaveManager(QObject):
     def _reset_state(self):
         from palobject import MappingCacheObject
         constants.loaded_level_json = None
+        constants.loaded_level_mtime = None
         constants.current_save_path = None
         constants.backup_save_path = None
         constants.srcGuildMapping = None
@@ -119,6 +120,7 @@ class SaveManager(QObject):
     def _load_from_path(self, level_sav_path: str, parent=None) -> bool:
         t0 = time.perf_counter()
         constants.loaded_level_json = sav_to_gvas_wrapper(level_sav_path)
+        constants.loaded_level_mtime = os.path.getmtime(level_sav_path)
         t1 = time.perf_counter()
         constants.invalidate_container_lookup()
         from palworld_aio.managers.func_manager import scan_and_protect_death_bags
@@ -206,7 +208,8 @@ class SaveManager(QObject):
         from resource_resolver import get_data_base
         base_path = get_data_base()
         t0 = time.perf_counter()
-        constants.loaded_level_json = sav_to_gvas_wrapper(level_sav_path)          
+        constants.loaded_level_json = sav_to_gvas_wrapper(level_sav_path)
+        constants.loaded_level_mtime = os.path.getmtime(level_sav_path)
         t1 = time.perf_counter()
         constants.invalidate_container_lookup()
         from palworld_aio.managers.func_manager import scan_and_protect_death_bags
@@ -240,6 +243,15 @@ class SaveManager(QObject):
         playerdir = os.path.join(constants.current_save_path, 'Players')
         self._process_scan_log(data_source, playerdir, log_folder, guild_name_map, base_path, illegal_pals_by_owner, owner_nicknames)
         return True
+    def is_save_stale(self, level_sav_path=None) -> bool:
+        if constants.loaded_level_mtime is None or not constants.current_save_path:
+            return False
+        if level_sav_path is None:
+            level_sav_path = os.path.join(constants.current_save_path, 'Level.sav')
+        try:
+            return os.path.getmtime(level_sav_path) != constants.loaded_level_mtime
+        except OSError:
+            return False
     def save_changes(self, parent=None):
         if not constants.current_save_path or not constants.loaded_level_json:
             return
@@ -247,6 +259,10 @@ class SaveManager(QObject):
             show_critical(parent, t('error.title'),
                 'Administrator privileges required to write XGP containers.')
             return
+        if not constants.xgp_loaded and self.is_save_stale():
+            if not show_question(parent, t('error.save_stale_title', default='Save File Changed'),
+                    t('error.save_stale_msg', default='Level.sav on disk has changed since it was loaded (it may have been re-saved by the game). Saving now will overwrite those changes with your in-memory edits.\n\nSave anyway?')):
+                return
         self._xgp_new_world_name = None
         if constants.xgp_loaded and parent:
             from PySide6.QtWidgets import QInputDialog, QLineEdit
@@ -282,6 +298,8 @@ class SaveManager(QObject):
                 constants.files_to_delete.clear()
                 if constants.xgp_loaded:
                     self._save_xgp_container()
+                else:
+                    constants.loaded_level_mtime = os.path.getmtime(level_sav_path)
             except Exception:
                 import traceback
                 traceback.print_exc()


### PR DESCRIPTION
## Summary
Partially addresses #197 (the stale-save-overwrite part; the Chinese localization gaps mentioned in that issue are not covered here and would need a separate pass).

- Tracks the on-disk mtime of `Level.sav` at load/reload time.
- Before writing on Save Changes, compares the current on-disk mtime against the one recorded at load. If the file changed externally (e.g. the user forgot to reload after playing/re-saving in-game), shows a Yes/No confirmation dialog instead of silently overwriting.
- Refreshes the tracked mtime after a successful save so it doesn't immediately re-trigger.
- Adds `error.save_stale_title` / `error.save_stale_msg` i18n keys to `en_US.json` and `zh_CN.json`. **The `zh_CN.json` translation was machine-assisted and should be verified by a native/fluent speaker before merge** — I can't vouch for its accuracy.

## Test plan
- [ ] Load a save, edit something, `touch` (or otherwise modify) `Level.sav` externally, click Save Changes — confirm the warning dialog appears and both Yes (saves) and No (cancels) work as expected.
- [ ] Normal load → edit → save flow (no external change) still saves without any prompt.
- [ ] Reload Current Save still works and resets the tracked mtime.