### PR TITLE
docs(compressor): explain why PlM saves are written with Kraken

### DIFF
--- a/src/palsav/palsav/compressor/oozlib.py
+++ b/src/palsav/palsav/compressor/oozlib.py
@@ -66,10 +66,15 @@ class OozLib(Compressor):
         if save_type != SaveType.PLM.value:
             raise ValueError(f'Unhandled compression type: 0x{save_type:02X}, only 0x31 (PLM) is supported')
         logger.debug('Compressing data...')
-        # Palworld itself writes PlM saves with Mermaid, not Kraken: recompressing
-        # an untouched official save with Mermaid/Normal reproduces it byte-for-byte,
-        # while Kraken yields a smaller but different (still valid) stream.
-        compressed_data = self.palooz.compress(OodleCompressor.Mermaid, OodleLevel.Normal, data, uncompressed_len)
+        # Palworld itself writes PlM saves with Mermaid, not Kraken: recompressing an
+        # untouched official save with Mermaid/Normal reproduces it byte-for-byte,
+        # while Kraken yields a smaller, valid, but different stream. The game reads
+        # either, so Kraken is kept here on purpose: the bundled ooz encoder only
+        # implements CompressBlock_Kraken and returns -1 for every other codec id
+        # (dep/ooz/compress.cpp), so selecting Mermaid makes each save raise at
+        # compress time. Byte-identity with the game would need an encoder that can
+        # actually write Mermaid.
+        compressed_data = self.palooz.compress(OodleCompressor.Kraken, OodleLevel.Normal, data, uncompressed_len)
         if not compressed_data:
             raise RuntimeError(f'palooz compress failed or returned empty result (code: {compressed_data})')
         compressed_len = len(compressed_data)

--- a/src/palsav/palsav/compressor/oozlib.py
+++ b/src/palsav/palsav/compressor/oozlib.py
@@ -66,7 +66,10 @@ class OozLib(Compressor):
         if save_type != SaveType.PLM.value:
             raise ValueError(f'Unhandled compression type: 0x{save_type:02X}, only 0x31 (PLM) is supported')
         logger.debug('Compressing data...')
-        compressed_data = self.palooz.compress(OodleCompressor.Kraken, OodleLevel.Normal, data, uncompressed_len)
+        # Palworld itself writes PlM saves with Mermaid, not Kraken: recompressing
+        # an untouched official save with Mermaid/Normal reproduces it byte-for-byte,
+        # while Kraken yields a smaller but different (still valid) stream.
+        compressed_data = self.palooz.compress(OodleCompressor.Mermaid, OodleLevel.Normal, data, uncompressed_len)
         if not compressed_data:
             raise RuntimeError(f'palooz compress failed or returned empty result (code: {compressed_data})')
         compressed_len = len(compressed_data)


### PR DESCRIPTION
### What this is now

The original patch switched PlM compression to Mermaid. **That was wrong** and the
Codex review caught it correctly — see the comment below. The PR has been reduced
to a comment-only change: **no behaviour changes**, `OodleCompressor.Kraken` stays.

### Why the comment is worth having

Palworld itself writes PlM saves with **Mermaid**, not Kraken. Verified by
decompressing and recompressing every file of an untouched v1.0.2.100933 save —
with Mermaid/Normal all 6 come back **byte-for-byte identical** (same sha256);
with Kraken they come back smaller and different (e.g. `Level.sav` 467,982 →
392,037 b).

That is a genuinely useful fact, but it is **not actionable here**, because the
bundled `ooz` encoder only implements `CompressBlock_Kraken` and returns `-1`
for every other codec id (`dep/ooz/compress.cpp`). Selecting Mermaid makes every
save raise at compress time.

So the comment records both halves: what the game does, and why this file
deliberately does something else. The next person who discovers the Mermaid
detail (someone will) reads it and doesn't ship the bug I almost did.

### Why my verification didn't catch it

I verified with the **official Oodle library** (`oo2core`, via `ctypes`), which
implements Mermaid encoding. `ooz` decodes every codec but only encodes Kraken —
so the finding was real and the proposed fix was still broken for this codebase.
My mistake was validating against one implementation and proposing a change to a
different one.

### If byte-identity is ever wanted

Only listing the options, not advocating any — the current choice looks
deliberate and reasonable to me:

1. **Keep Kraken** (this PR). The game reads it fine; output simply isn't
   identical to what the game wrote.
2. **Optional official Oodle path** — detect a user-supplied `oo2core` and use it
   when present, keeping `palooz` as the default. Gets byte-identity and a strong
   regression test (recompressing any official save must match its own sha256),
   at the cost of an extra code path. Oodle is proprietary, so it could only ever
   be user-supplied, never bundled — which I assume is exactly why `ooz` is here.
3. **Implement a Mermaid encoder in `ooz`** — real C++ work, probably not worth it
   for this benefit alone.

Happy to close this if you'd rather not carry the comment.