### PR TITLE
Fix font size on macOS by making label font size platform-dependent

### DIFF
--- a/src/palworld_aio/ui/chrome/sidebar_widget.py
+++ b/src/palworld_aio/ui/chrome/sidebar_widget.py
@@ -1,3 +1,4 @@
+import sys
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QPushButton, QLabel, QStyleOptionButton, QStylePainter, QStyle
 from PySide6.QtCore import Signal, Qt
 from PySide6.QtGui import QFont, QCursor, QPainter, QColor, QBrush, QFontMetrics
@@ -12,6 +13,7 @@ ICONS = {'tools': nf.icons.get('nf-fa-wrench', '\uf0ad'), 'map': nf.icons.get('n
 SIDEBAR_W_COLLAPSED = 48
 SIDEBAR_W_EXPANDED = 150
 ITEM_H = 44
+LABEL_FONT_SIZE = 10 if sys.platform == 'darwin' else 7
 class NerdBtn(QPushButton):
     def paintEvent(self, event):
         sp = QStylePainter(self)
@@ -104,7 +106,7 @@ class NavItem(QPushButton):
             x = 16 - br.x()
             y = (self.height() - br.height()) / 2 - br.y()
             p.drawText(int(x), int(y), text)
-            label_font = QFont(constants.FONT_FAMILY_NERD, 7)
+            label_font = QFont(constants.FONT_FAMILY_NERD, LABEL_FONT_SIZE)
             p.setFont(label_font)
             p.setPen(self.palette().color(self.foregroundRole()))
             lfm = QFontMetrics(label_font)
@@ -185,7 +187,7 @@ class BottomBtn(QPushButton):
             y = (self.height() - br.height()) / 2 - br.y()
             p.drawText(int(x), int(y), text)
             if self._label:
-                label_font = QFont(constants.FONT_FAMILY_NERD, 7)
+                label_font = QFont(constants.FONT_FAMILY_NERD, LABEL_FONT_SIZE)
                 p.setFont(label_font)
                 p.setPen(self.palette().color(self.foregroundRole()))
                 lfm = QFontMetrics(label_font)


### PR DESCRIPTION
The expanded sidebar labels were painted with a hardcoded QFont(constants.FONT_FAMILY_NERD, 7). 7pt renders acceptably on Windows but is extremely small on macOS due to how Qt maps point sizes on Retina displays.

Verified that tests pass:

```
299 passed, 20 deselected in 3.04s
```

Before:

<img width="635" height="587" alt="image" src="https://github.com/user-attachments/assets/353fcfd7-9655-47ad-bdd0-3ed10da20b69" />


After: 

<img width="628" height="580" alt="image" src="https://github.com/user-attachments/assets/3c0bdbe5-b867-466a-9f9f-a53afdd98abf" />

