### PR TITLE
Fix deleted pals coming back after saving

### DIFF
--- a/changelogs.md
+++ b/changelogs.md
@@ -10,6 +10,7 @@
 - **Save errors no longer hide behind "Saved successfully"** — if writing the save fails, a full error screen with details and a copy button appears instead of a false success message.
 - **Importing bases into a real save no longer fails** — the support check that treated normally-placed structures as unsupported has been relaxed, so existing bases import without being blocked.
 - **Newer work records now decode correctly** — the work entries the game creates for multi-recipe workbenches and fish ponds used to show up as unreadable raw data. They now load like any other work and roundtrip byte-for-byte, so editing, validation, and reference checks see every work in the save.
+- **Deleted pals stay deleted** — deleting a pal from Global Pal Storage or DPS storage looked like it worked, but the pal was back, fully intact, the next time you loaded the save. The slot was only half-cleared, so the pal's data was still sitting in the file and got read straight back in. Deleting now wipes the slot properly, whether you delete one pal, use the right-click delete, or delete a whole selection at once. Emptying DPS storage completely also failed to save at all, and now does.
 - Bumped version to 2.3.3
 
 #2.3.2

--- a/src/palworld_aio/editor/gps_editor.py
+++ b/src/palworld_aio/editor/gps_editor.py
@@ -663,11 +663,6 @@ class GpsEditorDialog(FramelessDialog):
         elif action == 'delete' and raw:
             if not show_question(self, t('edit_pals.confirm_delete'), 'Delete this GPS pal?'):
                 return
-            for k in list(raw.keys()):
-                if k != 'SlotId':
-                    del raw[k]
-            raw['CharacterID'] = {'id': None, 'type': 'NameProperty', 'value': 'None'}
-            raw['Level'] = {'id': None, 'type': 'ByteProperty', 'value': {'type': 'None', 'value': 1}}
             self._clear_gps_instance(abs_idx)
             self.pals.pop(abs_idx, None)
             self.slots[slot_idx].pal_data = None
@@ -823,6 +818,13 @@ class GpsEditorDialog(FramelessDialog):
             return
         arr = constants.gps_gvas.properties.get('SaveParameterArray', {}).get('value', {}).get('values', [])
         if abs_idx < len(arr) and isinstance(arr[abs_idx], dict):
+            sp = arr[abs_idx].get('SaveParameter', {}).get('value', {})
+            if isinstance(sp, dict):
+                for k in list(sp.keys()):
+                    if k != 'SlotId':
+                        del sp[k]
+                sp['CharacterID'] = {'id': None, 'type': 'NameProperty', 'value': 'None'}
+                sp['Level'] = {'id': None, 'type': 'ByteProperty', 'value': {'type': 'None', 'value': 1}}
             inst = arr[abs_idx].get('InstanceId')
             if isinstance(inst, dict):
                 empty = '00000000-0000-0000-0000-000000000000'

--- a/src/palworld_aio/editor/pal_editor/pal_editor_widget.py
+++ b/src/palworld_aio/editor/pal_editor/pal_editor_widget.py
@@ -616,6 +616,28 @@ class PalEditorWidget(QWidget, BulkOperationMixin):
             self._bulk_heal_pal(sender)
         elif action == 'bulk_max_buff':
             self._bulk_max_buff_pal(sender)
+    def _clear_dps_slot(self, abs_idx):
+        if not self.dps_gvas:
+            return
+        arr = self.dps_gvas.properties.get('SaveParameterArray', {}).get('value', {}).get('values', [])
+        if abs_idx >= len(arr) or not isinstance(arr[abs_idx], dict):
+            return
+        sp = arr[abs_idx].get('SaveParameter', {}).get('value', {})
+        if isinstance(sp, dict):
+            for k in list(sp.keys()):
+                if k != 'SlotId':
+                    del sp[k]
+            sp['CharacterID'] = {'id': None, 'type': 'NameProperty', 'value': 'None'}
+            sp['Level'] = {'id': None, 'type': 'ByteProperty', 'value': {'type': 'None', 'value': 1}}
+        inst = arr[abs_idx].get('InstanceId')
+        if isinstance(inst, dict):
+            empty_guid = '00000000-0000-0000-0000-000000000000'
+            inst_val = inst.get('value', {})
+            if isinstance(inst_val, dict):
+                inst_val['PlayerUId'] = {'struct_type': 'Guid', 'struct_id': empty_guid, 'id': None, 'value': empty_guid, 'type': 'StructProperty'}
+                inst_val['InstanceId'] = {'struct_type': 'Guid', 'struct_id': empty_guid, 'id': None, 'value': empty_guid, 'type': 'StructProperty'}
+                inst_val['DebugName'] = {'id': None, 'type': 'StrProperty', 'value': ''}
+
     def _delete_dps_pal(self, slot_index):
         abs_idx = (self.current_box_index - 1) * 30 + slot_index
         target = self.dps_pals.get(abs_idx)
@@ -625,22 +647,7 @@ class PalEditorWidget(QWidget, BulkOperationMixin):
         reply = show_question(self, t('edit_pals.confirm_delete'), 'Delete this DPS pal?')
         if not reply:
             return
-        for k in list(raw.keys()):
-            if k != 'SlotId':
-                del raw[k]
-        raw['CharacterID'] = {'id': None, 'type': 'NameProperty', 'value': 'None'}
-        raw['Level'] = {'id': None, 'type': 'ByteProperty', 'value': {'type': 'None', 'value': 1}}
-        if self.dps_gvas:
-            arr = self.dps_gvas.properties.get('SaveParameterArray', {}).get('value', {}).get('values', [])
-            if abs_idx < len(arr) and isinstance(arr[abs_idx], dict):
-                inst = arr[abs_idx].get('InstanceId')
-                if isinstance(inst, dict):
-                    empty_guid = '00000000-0000-0000-0000-000000000000'
-                    inst_val = inst.get('value', {})
-                    if isinstance(inst_val, dict):
-                        inst_val['PlayerUId'] = {'struct_type': 'Guid', 'struct_id': empty_guid, 'id': None, 'value': empty_guid, 'type': 'StructProperty'}
-                        inst_val['InstanceId'] = {'struct_type': 'Guid', 'struct_id': empty_guid, 'id': None, 'value': empty_guid, 'type': 'StructProperty'}
-                        inst_val['DebugName'] = {'id': None, 'type': 'StrProperty', 'value': ''}
+        self._clear_dps_slot(abs_idx)
         del self.dps_pals[abs_idx]
         self.palbox_slots[slot_index].pal_data = None
         self.palbox_slots[slot_index].update_display()
@@ -1401,19 +1408,9 @@ class PalEditorWidget(QWidget, BulkOperationMixin):
             self.palbox_pal_dict.pop(abs_idx, None)
         for abs_idx in removed_dps:
             self.dps_pals.pop(abs_idx, None)
-            if self.dps_gvas:
-                arr = self.dps_gvas.properties.get('SaveParameterArray', {}).get('value', {}).get('values', [])
-                if abs_idx < len(arr) and isinstance(arr[abs_idx], dict):
-                    inst = arr[abs_idx].get('InstanceId')
-                    if isinstance(inst, dict):
-                        empty_guid = '00000000-0000-0000-0000-000000000000'
-                        inst_val = inst.get('value', {})
-                        if isinstance(inst_val, dict):
-                            inst_val['PlayerUId'] = {'struct_type': 'Guid', 'struct_id': empty_guid, 'id': None, 'value': empty_guid, 'type': 'StructProperty'}
-                            inst_val['InstanceId'] = {'struct_type': 'Guid', 'struct_id': empty_guid, 'id': None, 'value': empty_guid, 'type': 'StructProperty'}
-                            inst_val['DebugName'] = {'id': None, 'type': 'StrProperty', 'value': ''}
-            if self.dps_pals and hasattr(self, '_save_dps'):
-                self._save_dps(force=True)
+            self._clear_dps_slot(abs_idx)
+        if removed_dps and self.dps_gvas:
+            self._save_dps(force=True)
         self._clear_multi_selection()
         self._clicked_pal = None
         self.selected_pal_slot = None


### PR DESCRIPTION
Deleting a pal from Global Pal Storage or DPS storage only cleared the slot's InstanceId, leaving the pal's SaveParameter data in the file. The loaders decide if a slot is occupied from CharacterID alone, so the pal was back on the next load.

The single-pal delete already cleared the data properly. The direct delete and the bulk delete did not. Moved the clearing into one shared place so all of them do it.

Also, bulk DPS delete saved inside its loop, guarded on the pal list still having something in it, so deleting every pal in DPS storage never saved at all.