### PR TITLE
Drag pals between slots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,7 @@ PST_standalone*.zip
 # Rust migration workspace + web frontend (developed on the rust/tauri branch)
 /rust/
 /web/
+
+# Pal exports created while testing
+*.pstpal
+*.pstbase

--- a/changelogs.md
+++ b/changelogs.md
@@ -10,6 +10,7 @@
 - **Save errors no longer hide behind "Saved successfully"** — if writing the save fails, a full error screen with details and a copy button appears instead of a false success message.
 - **Importing bases into a real save no longer fails** — the support check that treated normally-placed structures as unsupported has been relaxed, so existing bases import without being blocked.
 - **Newer work records now decode correctly** — the work entries the game creates for multi-recipe workbenches and fish ponds used to show up as unreadable raw data. They now load like any other work and roundtrip byte-for-byte, so editing, validation, and reference checks see every work in the save.
+- **Drag pals between slots** — you can now pick a pal up and drop it on another slot to rearrange your storage. Dropping it on an empty slot moves it there, dropping it on another pal swaps the two. Works in Global Pal Storage, the palbox, DPS storage and your party, and the new positions are saved so the game sees the same order. Dragging is limited to the grid you started in, so a pal cannot accidentally be dropped into a different storage.
 - Bumped version to 2.3.3
 
 #2.3.2

--- a/src/palworld_aio/editor/gps_editor.py
+++ b/src/palworld_aio/editor/gps_editor.py
@@ -197,6 +197,7 @@ class GpsEditorDialog(FramelessDialog):
                 slot.rightClicked.connect(self._on_slot_right_clicked)
                 slot.entered.connect(partial(self._on_slot_entered, idx))
                 slot.left.connect(self._on_slot_left)
+                slot.slotDropped.connect(self._on_slot_dropped)
                 self.grid_layout.addWidget(slot, row, col)
                 self.slots.append(slot)
 
@@ -799,6 +800,33 @@ class GpsEditorDialog(FramelessDialog):
             self._update_page()
             self._refresh_info()
             self._mark_modified()
+
+    def _on_slot_dropped(self, src_rel, dst_rel):
+        start = (self.current_page - 1) * PAGE_SIZE
+        if self._swap_gps_slots(start + src_rel, start + dst_rel):
+            self._clear_multi_selection()
+            self._clear_selection()
+            self._update_page()
+            self._mark_modified()
+
+    def _swap_gps_slots(self, a, b):
+        if a == b or not constants.gps_gvas:
+            return False
+        arr = constants.gps_gvas.properties.get('SaveParameterArray', {}).get('value', {}).get('values', [])
+        if not (0 <= a < len(arr) and 0 <= b < len(arr)):
+            return False
+        arr[a], arr[b] = arr[b], arr[a]
+        for idx in (a, b):
+            sp = arr[idx].get('SaveParameter', {}).get('value', {})
+            cid = extract_value(sp, 'CharacterID', 'None') if isinstance(sp, dict) else 'None'
+            if not cid or cid == 'None':
+                self.pals.pop(idx, None)
+                continue
+            si = safe_nested_get(sp, ['SlotId', 'value', 'SlotIndex'])
+            if isinstance(si, dict):
+                si['value'] = idx
+            self.pals[idx] = {'data': sp}
+        return True
 
     def _set_gps_slot(self, abs_idx, raw_data):
         if not constants.gps_gvas:

--- a/src/palworld_aio/editor/pal_editor/pal_editor_widget.py
+++ b/src/palworld_aio/editor/pal_editor/pal_editor_widget.py
@@ -108,6 +108,7 @@ class PalEditorWidget(QWidget, BulkOperationMixin):
             slot.clicked.connect(partial(self._on_party_slot_clicked, i))
             slot.rightClicked.connect(self._on_slot_right_clicked)
             slot.entered.connect(partial(self._on_party_slot_entered, i))
+            slot.slotDropped.connect(self._on_party_slot_dropped)
             slot.left.connect(self._on_party_slot_left)
             party_layout.addWidget(slot)
             self.party_slots.append(slot)
@@ -238,6 +239,7 @@ class PalEditorWidget(QWidget, BulkOperationMixin):
                 slot.clicked.connect(partial(self._on_palbox_slot_clicked, idx))
                 slot.rightClicked.connect(self._on_slot_right_clicked)
                 slot.entered.connect(partial(self._on_palbox_slot_entered, idx))
+                slot.slotDropped.connect(self._on_palbox_slot_dropped)
                 slot.left.connect(self._on_palbox_slot_left)
                 self.grid_layout.addWidget(slot, row, col)
                 self.palbox_slots.append(slot)
@@ -878,6 +880,96 @@ class PalEditorWidget(QWidget, BulkOperationMixin):
         self._update_dashboard_stats()
         self._increment_pal_count()
         show_information(self, 'Clone Pal', 'Pal cloned successfully.')
+    def _on_party_slot_dropped(self, src_idx, dst_idx):
+        if self._move_container_pal(self.party_pals, self.party_container, src_idx, dst_idx):
+            self._after_slot_move()
+
+    def _on_palbox_slot_dropped(self, src_rel, dst_rel):
+        start = (self.current_box_index - 1) * 30
+        src, dst = start + src_rel, start + dst_rel
+        if self._palbox_mode == 'dps':
+            moved = self._swap_dps_slots(src, dst)
+        else:
+            moved = self._move_container_pal(self.palbox_pal_dict, self.palbox_container, src, dst)
+        if moved:
+            if self._palbox_mode == 'dps':
+                self._mark_dps_modified()
+            self._after_slot_move()
+
+    def _after_slot_move(self):
+        self._clear_multi_selection()
+        self._clicked_pal = None
+        self.selected_pal_slot = None
+        self.pal_info.set_clicked_pal(None)
+        self._update_party_slots()
+        self._update_palbox_page()
+        self._update_box_label()
+        constants.dirty = True
+
+    def _container_slot_entries(self, container_id):
+        if not container_id or not constants.loaded_level_json:
+            return []
+        target = str(container_id).replace('-', '').lower()
+        wsd = constants.loaded_level_json['properties']['worldSaveData']['value']
+        for cont in safe_nested_get(wsd, ['CharacterContainerSaveData', 'value'], []) or []:
+            cid = safe_nested_get(cont, ['key', 'ID', 'value'])
+            if cid and str(cid).replace('-', '').lower() == target:
+                return safe_nested_get(cont, ['value', 'Slots', 'value', 'values'], []) or []
+        return []
+
+    def _move_container_pal(self, pal_dict, container_id, src, dst):
+        if src == dst or src not in pal_dict:
+            return False
+        src_pal = pal_dict[src]
+        dst_pal = pal_dict.get(dst)
+        moves = {self._instance_key(src_pal): dst}
+        if dst_pal is not None:
+            moves[self._instance_key(dst_pal)] = src
+        for entry in self._container_slot_entries(container_id):
+            inst = safe_nested_get(entry, ['RawData', 'value', 'instance_id'])
+            key = str(inst).replace('-', '').lower() if inst else ''
+            if key in moves:
+                si = entry.get('SlotIndex')
+                if isinstance(si, dict):
+                    si['value'] = moves[key]
+        for pal, new_idx in ((src_pal, dst), (dst_pal, src)):
+            if pal is None:
+                continue
+            raw = _get_raw_from_item(pal)
+            si = safe_nested_get(raw, ['SlotId', 'value', 'SlotIndex'])
+            if isinstance(si, dict):
+                si['value'] = new_idx
+        pal_dict[dst] = src_pal
+        if dst_pal is not None:
+            pal_dict[src] = dst_pal
+        else:
+            pal_dict.pop(src, None)
+        return True
+
+    @staticmethod
+    def _instance_key(pal):
+        inst = safe_nested_get(pal, ['key', 'InstanceId', 'value'])
+        return str(inst).replace('-', '').lower() if inst else ''
+
+    def _swap_dps_slots(self, a, b):
+        if a == b or not self.dps_gvas:
+            return False
+        arr = self.dps_gvas.properties.get('SaveParameterArray', {}).get('value', {}).get('values', [])
+        if not (0 <= a < len(arr) and 0 <= b < len(arr)):
+            return False
+        arr[a], arr[b] = arr[b], arr[a]
+        for idx in (a, b):
+            sp = arr[idx].get('SaveParameter', {}).get('value', {})
+            cid = extract_value(sp, 'CharacterID', 'None') if isinstance(sp, dict) else 'None'
+            if not cid or cid == 'None':
+                self.dps_pals.pop(idx, None)
+                continue
+            si = safe_nested_get(sp, ['SlotId', 'value', 'SlotIndex'])
+            if isinstance(si, dict):
+                si['value'] = idx
+            self.dps_pals[idx] = {'data': sp}
+        return True
+
     def _export_pal(self, sender):
         if not hasattr(sender, 'pal_data') or sender.pal_data is None:
             return

--- a/src/palworld_aio/editor/pal_editor/palbox_slot_widget.py
+++ b/src/palworld_aio/editor/pal_editor/palbox_slot_widget.py
@@ -1,6 +1,6 @@
-from PySide6.QtWidgets import QFrame, QLabel, QMenu, QSizePolicy, QStyledItemDelegate, QStyle
-from PySide6.QtCore import Qt, Signal
-from PySide6.QtGui import QColor, QPainter
+from PySide6.QtWidgets import QApplication, QFrame, QLabel, QMenu, QSizePolicy, QStyledItemDelegate, QStyle
+from PySide6.QtCore import QMimeData, Qt, Signal
+from PySide6.QtGui import QColor, QDrag, QPainter
 from i18n import t
 from palworld_aio.ui.chrome.styles import slot_full, slot_selected, slot_multi_selected
 from palworld_aio.utils import extract_value, resolve_name, safe_nested_get
@@ -19,7 +19,7 @@ from .icons import (
     _strip_prefix_label,
 )
 from .pal_ops import build_pal_context_menu
-from .widgets import StrokedLabel
+from .widgets import StrokedLabel, PAL_SLOT_MIME
 from .legacy_frame import PalFrame
 from .pal_info_widget import PalInfoWidget
 
@@ -29,6 +29,8 @@ class PalboxSlotWidget(QFrame):
     clicked = Signal()
 
     rightClicked = Signal(int, str)
+
+    slotDropped = Signal(int, int)
 
     entered = Signal()
 
@@ -47,6 +49,10 @@ class PalboxSlotWidget(QFrame):
         self.multi_selected = False
 
         self._click_modifiers = Qt.NoModifier
+
+        self._drag_origin = None
+
+        self.setAcceptDrops(True)
 
         self.setObjectName('palboxSlot')
 
@@ -134,9 +140,99 @@ class PalboxSlotWidget(QFrame):
 
             self._click_modifiers = event.modifiers()
 
+            self._drag_origin = event.position().toPoint() if self.pal_data else None
+
             self.clicked.emit()
 
         super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):
+
+        if self._drag_origin is not None and (event.buttons() & Qt.LeftButton) and self.pal_data:
+
+            if (event.position().toPoint() - self._drag_origin).manhattanLength() >= QApplication.startDragDistance():
+
+                self._start_slot_drag()
+
+                return
+
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event):
+
+        self._drag_origin = None
+
+        super().mouseReleaseEvent(event)
+
+    def _start_slot_drag(self):
+
+        self._drag_origin = None
+
+        drag = QDrag(self)
+
+        mime = QMimeData()
+
+        mime.setData(PAL_SLOT_MIME, str(self.slot_index).encode('utf-8'))
+
+        drag.setMimeData(mime)
+
+        pm = self.grab()
+
+        drag.setPixmap(pm)
+
+        drag.setHotSpot(pm.rect().center())
+
+        drag.exec(Qt.MoveAction)
+
+    def _drag_is_sibling(self, event):
+
+        src = event.source()
+
+        return src is not None and src is not self and src.parent() is self.parent()
+
+    def dragEnterEvent(self, event):
+
+        if event.mimeData().hasFormat(PAL_SLOT_MIME) and self._drag_is_sibling(event):
+
+            event.acceptProposedAction()
+
+        else:
+
+            event.ignore()
+
+    def dragMoveEvent(self, event):
+
+        if event.mimeData().hasFormat(PAL_SLOT_MIME) and self._drag_is_sibling(event):
+
+            event.acceptProposedAction()
+
+        else:
+
+            event.ignore()
+
+    def dropEvent(self, event):
+
+        if not (event.mimeData().hasFormat(PAL_SLOT_MIME) and self._drag_is_sibling(event)):
+
+            event.ignore()
+
+            return
+
+        try:
+
+            src_index = int(bytes(event.mimeData().data(PAL_SLOT_MIME)).decode('utf-8'))
+
+        except (TypeError, ValueError):
+
+            event.ignore()
+
+            return
+
+        event.acceptProposedAction()
+
+        if src_index != self.slot_index:
+
+            self.slotDropped.emit(src_index, self.slot_index)
 
     def mouseDoubleClickEvent(self, event):
 

--- a/src/palworld_aio/editor/pal_editor/party_slot_widget.py
+++ b/src/palworld_aio/editor/pal_editor/party_slot_widget.py
@@ -1,5 +1,6 @@
-from PySide6.QtWidgets import QFrame, QHBoxLayout, QLabel, QMenu, QProgressBar, QSizePolicy, QVBoxLayout, QWidget
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import QApplication, QFrame, QHBoxLayout, QLabel, QMenu, QProgressBar, QSizePolicy, QVBoxLayout, QWidget
+from PySide6.QtCore import QMimeData, Qt, Signal
+from PySide6.QtGui import QDrag
 from i18n import t
 from palworld_aio.ui.chrome.styles import slot_full, slot_selected, slot_multi_selected
 from palworld_aio.utils import calculate_max_hp, extract_value, resolve_name, safe_nested_get, _hp_breakdown, stat_breakdown_tooltip
@@ -18,7 +19,7 @@ from .icons import (
     _strip_prefix_label,
 )
 from .pal_ops import build_pal_context_menu
-from .widgets import StrokedLabel
+from .widgets import StrokedLabel, PAL_SLOT_MIME
 from .legacy_frame import PalFrame
 from .pal_info_widget import PalInfoWidget
 
@@ -30,6 +31,8 @@ class PartySlotWidget(QFrame):
     clicked = Signal()
 
     rightClicked = Signal(int, str)
+
+    slotDropped = Signal(int, int)
 
     entered = Signal()
 
@@ -48,6 +51,10 @@ class PartySlotWidget(QFrame):
         self.multi_selected = False
 
         self._click_modifiers = Qt.NoModifier
+
+        self._drag_origin = None
+
+        self.setAcceptDrops(True)
 
         self.setObjectName('partySlot')
 
@@ -119,9 +126,99 @@ class PartySlotWidget(QFrame):
 
             self._click_modifiers = event.modifiers()
 
+            self._drag_origin = event.position().toPoint() if self.pal_data else None
+
             self.clicked.emit()
 
         super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):
+
+        if self._drag_origin is not None and (event.buttons() & Qt.LeftButton) and self.pal_data:
+
+            if (event.position().toPoint() - self._drag_origin).manhattanLength() >= QApplication.startDragDistance():
+
+                self._start_slot_drag()
+
+                return
+
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event):
+
+        self._drag_origin = None
+
+        super().mouseReleaseEvent(event)
+
+    def _start_slot_drag(self):
+
+        self._drag_origin = None
+
+        drag = QDrag(self)
+
+        mime = QMimeData()
+
+        mime.setData(PAL_SLOT_MIME, str(self.slot_index).encode('utf-8'))
+
+        drag.setMimeData(mime)
+
+        pm = self.grab()
+
+        drag.setPixmap(pm)
+
+        drag.setHotSpot(pm.rect().center())
+
+        drag.exec(Qt.MoveAction)
+
+    def _drag_is_sibling(self, event):
+
+        src = event.source()
+
+        return src is not None and src is not self and src.parent() is self.parent()
+
+    def dragEnterEvent(self, event):
+
+        if event.mimeData().hasFormat(PAL_SLOT_MIME) and self._drag_is_sibling(event):
+
+            event.acceptProposedAction()
+
+        else:
+
+            event.ignore()
+
+    def dragMoveEvent(self, event):
+
+        if event.mimeData().hasFormat(PAL_SLOT_MIME) and self._drag_is_sibling(event):
+
+            event.acceptProposedAction()
+
+        else:
+
+            event.ignore()
+
+    def dropEvent(self, event):
+
+        if not (event.mimeData().hasFormat(PAL_SLOT_MIME) and self._drag_is_sibling(event)):
+
+            event.ignore()
+
+            return
+
+        try:
+
+            src_index = int(bytes(event.mimeData().data(PAL_SLOT_MIME)).decode('utf-8'))
+
+        except (TypeError, ValueError):
+
+            event.ignore()
+
+            return
+
+        event.acceptProposedAction()
+
+        if src_index != self.slot_index:
+
+            self.slotDropped.emit(src_index, self.slot_index)
 
     def mouseDoubleClickEvent(self, event):
 

--- a/src/palworld_aio/editor/pal_editor/widgets.py
+++ b/src/palworld_aio/editor/pal_editor/widgets.py
@@ -7,6 +7,9 @@ from palworld_aio import constants
 from resource_resolver import resource_path
 from palworld_aio.ui.chrome.styles import TOOLTIP_STYLE
 
+PAL_SLOT_MIME = 'application/x-pst-pal-slot'
+
+
 class FramelessDialog(QDialog):
 
     def __init__(self, title_key='edit_pals.title', parent=None):


### PR DESCRIPTION
Pal slots can now be dragged onto each other. Dropping on an empty slot moves the pal, dropping on another pal swaps the two. Added to the two slot widgets, so it works in Global Pal Storage, the palbox, DPS storage and the party.

The two storage types needed different handling. GPS and DPS are arrays where the index is the slot, so the entries are swapped whole and each pal keeps its own InstanceId. The palbox and party live in the container save data, where the loader uses the container's slot list rather than the pal's own SlotId, so both are updated together, otherwise pals would look moved in the editor and go back to where they were in game.

A drag only drops on a slot in the same grid, so a pal cannot be dropped into a different storage and end up pointing at the wrong container.